### PR TITLE
Adding small change to LESS code for portal page and updating change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,8 @@ the browser clipboard.
 ### Changed
 - Function of 'Show Web Calls' button so that only one call, based on which result type radio button is selected, is shown
 
+### Fixed
+- Media breakpoint formatting that caused 'Select data to download' radio buttons to be inaccessible at screen widths
+between 768px and 992px
+  
 [Unreleased]: https://github.com/NWQMC/WQP_UI/compare/WQP_UI-5.7.0...master

--- a/assets/less/portal_form.less
+++ b/assets/less/portal_form.less
@@ -389,7 +389,8 @@
     .make-lg-column(4);
   }
   #download-sorted-data-div {
-    .make-md-column(2);
+    .make-sm-column(6);
+    .make-md-column(5);
     .make-lg-column(4);
   }
   #form-action {


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WQP-1234
Some of the radio buttons will not work when in a two column layout
-----------
https://internal.cida.usgs.gov/jira/browse/WQP-1234 
The 'Select data to download' radio buttons could not be clicked when the browser width was between 768px and 992px.

Description
-----------
The 'div' element for the 'Sort data' checkbox was overlapping the element containing the 'Select data to download' radio buttons. Only as small change to the LESS code was required to fix.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
