### PR TITLE
Wqp 1215 - Link WQP UI activity download to the new activity data profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Updated python dependencies
+- Activity download uses a dataProfile in order to get all of the columns.
 
 ## [5.9.0]
 ### Added

--- a/assets/js/views/dataDetailsView.js
+++ b/assets/js/views/dataDetailsView.js
@@ -27,6 +27,7 @@ export default class DataDetailsView {
         let $site = this.$container.find('#sites');
         let $biosamples = this.$container.find('#biosamples');
         let $narrowResults = this.$container.find('#narrowsamples');
+        let $activity = this.$container.find('#activity-input');
 
         let $sorted = this.$container.find('#sorted');
         let $hiddenSorted = this.$container.find('input[type="hidden"][name="sorted"]');
@@ -67,13 +68,15 @@ export default class DataDetailsView {
 
             setEnabled($kml, $site.prop('checked'));
 
-            // If biological results or narrow results desired add a hidden input, otherwise remove it.
+            // If activity, biological results or narrow results desired add a hidden input to set the
+            // dataProfile, otherwise remove it.
             $dataProfile.remove();
             if ($biosamples.prop('checked')) {
                 this.$container.append('<input type="hidden" name="dataProfile" value="biological" />');
-
             } else if ($narrowResults.prop('checked')){
                 this.$container.append('<input type="hidden" name="dataProfile" value="narrowResult" />');
+            } else if ($activity.prop('checked')) {
+                this.$container.append('<input type="hidden" name="dataProfile" value="activityAll" />');
             }
 
             this.updateResultTypeAction(resultType);

--- a/assets/test/js/portal_ui/views/dataDetailsViewSpec.js
+++ b/assets/test/js/portal_ui/views/dataDetailsViewSpec.js
@@ -148,6 +148,15 @@ describe('Tests for DataDetailsView', function() {
         expect($testDiv.find('input[type="hidden"][name="dataProfile"]').length).toBe(0);
     });
 
+    it('Expects that if the activity radio button is checked, a hidden input is added with name dataProfile', function() {
+        testView.initialize();
+        $activity.prop('checked', true).trigger('change');
+        expect($testDiv.find('input[type="hidden"][name="dataProfile"]').length).toBe(1);
+
+        $sites.prop('checked', true).trigger('change');
+        expect($testDiv.find('input[type="hidden"][name="dataProfile"]').length).toBe(0);
+    });
+
     it('Expects that changing the sort checkbox updates the hidden sorted input', function() {
         testView.initialize();
         $sorted.prop('checked', true).trigger('change');


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [X] Update the changelog appropriately

Link WQP UI activity download to the new activity data profile

Description
-----------
Use the dataProfile activityAll when checking the Activities radio button

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
