### PR TITLE
fix download bug when syncing between basic and advanced forms, fixed tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update NLDI url for downloads
 - Query strings update when NLDI map returns sites
 - Added search and download functionality to basic form
+- Fix download bug when switching between basic and advanced form
 
 ## [5.24.0](https://github.com/NWQMC/WQP_UI/compare/WQP_UI-5.23.0...WQP_UI-5.24.0) - 2021-05-10
 ### Changed

--- a/assets/js/downloadProgressDialog.js
+++ b/assets/js/downloadProgressDialog.js
@@ -67,7 +67,7 @@ export default class DownloadProgressDialog {
 
     show(thisOpKind, dialogMessage) {
         let elements = this.getFormElements();
-        if(elements['StatusModal'].hidden){
+        if(elements['StatusModal'] && elements['StatusModal'].hidden){
             elements['StatusModal'].hidden = false;
         }
         var message = dialogMessage ? dialogMessage : 'Validating query ... Please wait.';
@@ -76,6 +76,13 @@ export default class DownloadProgressDialog {
         elements['DownloadButtons'].innerHTML = '';
         elements['Description'].innerHTML = message;
         elements['Heading'].innerHTML = (DIALOG[this.opKind].title);
+        // Remove existing continue and close buttons
+        if (document.getElementById('continueButton')){
+            document.getElementById('continueButton').remove();
+        }
+        if (document.getElementById('closeDownloadModal')){
+            document.getElementById('closeDownloadModal').remove();
+        }
     }
 
     updateProgress(counts, resultType, fileFormat, continueFnc) {
@@ -114,13 +121,13 @@ export default class DownloadProgressDialog {
             elements['Description'].innerHTML = `${getCountMessage()}<p>Click Continue to ${DIALOG[this.opKind].continueMessage}`;
             elements['DownloadButtons'].innerHTML = `${this.buttonHtml('closeDownloadModal', 'Cancel')}${this.buttonHtml('continueButton', 'Continue')}`;
             document.getElementById('continueButton').onclick = function() {
-                if(!elements['StatusModal'].hidden){
+                if(elements['StatusModal'] && !elements['StatusModal'].hidden){
                     elements['StatusModal'].hidden = true;
                 }
                 continueFnc(totalCount);
             };
             document.getElementById('closeDownloadModal').onclick = function() {
-                if(!elements['StatusModal'].hidden){
+                if(elements['StatusModal'] && !elements['StatusModal'].hidden){
                     elements['StatusModal'].hidden = true;
                 }
             };

--- a/assets/test/js/portal_ui/downloadProgressDialogSpec.js
+++ b/assets/test/js/portal_ui/downloadProgressDialogSpec.js
@@ -17,7 +17,7 @@ describe('Tests for DownloadProgressDialog', function () {
                 '<ul class="usa-button-group" id="downloadButtons"></ul>'+
             '</div>'
 
-        thisDialog = new DownloadProgressDialog(document.getElementById('download-status-modal'));
+        thisDialog = new DownloadProgressDialog(document.getElementById('download-status-modal'), "advanced");
         continueSpy = jasmine.createSpy('continueSpy');
     });
     afterEach(function () {

--- a/assets/test/js/portal_ui/nldiModelSpec.js
+++ b/assets/test/js/portal_ui/nldiModelSpec.js
@@ -87,13 +87,13 @@ describe('nldiModel', function() {
             .toEqual(`${Config.NLDI_SERVICES_ENDPOINT}nwissite/USGS-01010101/navigate/UT/dsSource?f=json&distance=12`);
     });
 
-    it('Expects getUrl without a distance parameter does not contain the distance query parameter', function() {
+    it('Expects getUrl without a distance parameter containts the distance query parameter 9999', function() {
         nldiModel.setData('featureSource', nldiModel.FEATURE_SOURCES[0]);
         nldiModel.setData('featureId', 'USGS-01010101');
         nldiModel.setData('navigation', nldiModel.NAVIGATION_MODES[2]);
 
         expect(nldiModel.getUrl('dsSource'))
-            .toEqual(`${Config.NLDI_SERVICES_ENDPOINT}nwissite/USGS-01010101/navigate/UT/dsSource?f=json&`);
+            .toEqual(`${Config.NLDI_SERVICES_ENDPOINT}nwissite/USGS-01010101/navigate/UT/dsSource?f=json&distance=9999`);
     });
 
     it('Expects setUrl will set the appropriate model elements', () => {

--- a/assets/test/js/portal_ui/views/downloadFormViewSpec.js
+++ b/assets/test/js/portal_ui/views/downloadFormViewSpec.js
@@ -89,7 +89,7 @@ describe('Tests for DownloadFormView', function() {
         expect(SamplingParameterInputView.prototype.initialize).toHaveBeenCalled();
         expect(BiologicalSamplingInputView.prototype.initialize).toHaveBeenCalled();
         expect(DataDetailsView.prototype.initialize).toHaveBeenCalled();
-        expect(NldiView.prototype.initialize).toHaveBeenCalled();
+        expect(NldiView.prototype.initialize).not.toHaveBeenCalled();
     });
 
     it('Expects that the providers are fetched', function() {

--- a/assets/test/js/portal_ui/views/siteParameterInputViewSpec.js
+++ b/assets/test/js/portal_ui/views/siteParameterInputViewSpec.js
@@ -74,7 +74,7 @@ describe('Tests for SiteParameterInputView', function() {
         expect(CodeSelect.prototype.initialize.calls.argsFor(0)[0].attr('id')).toEqual($siteType.attr('id'));
 
         fetchOrgDeferred.resolve();
-        expect(CodeSelect.prototype.initialize.calls.count()).toBe(2);
+        expect(CodeSelect.prototype.initialize.calls.count()).toBe(3);
         expect(CodeSelect.prototype.initialize.calls.argsFor(2)[0].attr('id')).toEqual($organization.attr('id'));
     });
 


### PR DESCRIPTION
- Fixed issue where download doesn't work when switching to advanced form, after downloading from basic form.
- Fixed tests for downloadFormView, nldiModel, siteParameterInputView and downloadProgressDialog.

Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
