### PR TITLE
Wqp 1782 only site profile is downloading

### DIFF
--- a/assets/js/DownloadProgressDialog.vue
+++ b/assets/js/DownloadProgressDialog.vue
@@ -83,6 +83,7 @@ export default {
         }
     },
     updateProgress(counts, resultType, fileFormat, continueFnc) {
+      console.log(`in update progress with resultType ${resultType}, fileFormat ${fileFormat}`)
         let elements = this.getFormElements();
         var totalCount = counts.total[RESULT_TYPE_TO_TOTAL_COUNT_PROPERTY_MAP[resultType]];
         let self = this;

--- a/assets/js/DownloadProgressDialog.vue
+++ b/assets/js/DownloadProgressDialog.vue
@@ -46,13 +46,13 @@ export default {
   methods: {
     getFormElements(){
         let elements;
-        if (this.formType == "advanced"){
+        if (this.formType === "advanced") {
             elements = {'StatusModal': document.getElementById('download-status-modal'), 
                 'DownloadButtons': document.getElementById('downloadButtons'),
                 'Description': document.getElementById('download-modal-description'),
                 'Heading': document.getElementById('download-modal-heading')};
         }
-        else{
+        else {
             elements = {'StatusModal': document.getElementById('download-status-modal-basic'),
             'DownloadButtons': document.getElementById('downloadButtonsBasic'),
             'Description': document.getElementById('download-modal-basic-description'),
@@ -83,7 +83,6 @@ export default {
         }
     },
     updateProgress(counts, resultType, fileFormat, continueFnc) {
-      console.log(`in update progress with resultType ${resultType}, fileFormat ${fileFormat}`)g
         let elements = this.getFormElements();
         var totalCount = counts.total[RESULT_TYPE_TO_TOTAL_COUNT_PROPERTY_MAP[resultType]];
         let self = this;

--- a/assets/js/DownloadProgressDialog.vue
+++ b/assets/js/DownloadProgressDialog.vue
@@ -83,7 +83,7 @@ export default {
         }
     },
     updateProgress(counts, resultType, fileFormat, continueFnc) {
-      console.log(`in update progress with resultType ${resultType}, fileFormat ${fileFormat}`)
+      console.log(`in update progress with resultType ${resultType}, fileFormat ${fileFormat}`)g
         let elements = this.getFormElements();
         var totalCount = counts.total[RESULT_TYPE_TO_TOTAL_COUNT_PROPERTY_MAP[resultType]];
         let self = this;

--- a/assets/js/portalOnReady.js
+++ b/assets/js/portalOnReady.js
@@ -214,8 +214,7 @@ document.addEventListener("DOMContentLoaded", function() {
                   propsData: {
                     container: document.querySelector('#show-queries-div'),
                     getQueryParamArray: downloadFormView.getQueryParamArray.bind(downloadFormView),
-                    // getResultType: downloadFormView.getResultType.bind(downloadFormView)
-                      getResultType: store.state.resultType
+                    getResultType: downloadFormView.getResultType.bind(downloadFormView)
                   }
                 });
 

--- a/assets/js/portalOnReady.js
+++ b/assets/js/portalOnReady.js
@@ -214,7 +214,8 @@ document.addEventListener("DOMContentLoaded", function() {
                   propsData: {
                     container: document.querySelector('#show-queries-div'),
                     getQueryParamArray: downloadFormView.getQueryParamArray.bind(downloadFormView),
-                    getResultType: downloadFormView.getResultType.bind(downloadFormView)
+                    // getResultType: downloadFormView.getResultType.bind(downloadFormView)
+                      getResultType: store.state.resultType
                   }
                 });
 

--- a/assets/js/queryService.js
+++ b/assets/js/queryService.js
@@ -85,15 +85,12 @@ export default {
      * @param {String} queryParams - a query string
      * @returns {String} - the url and query params to download data
      */
-	
     getFormUrl: function(resultType, queryParams) {
-        console.log('getFormUrl resultType', resultType)
-        console.log('getFormUrl queryParams', queryParams)
         var result = Config.QUERY_URLS[resultType];
         if (queryParams) {
             result = result + '?' + queryParams;
         }
-        console.log('getFormUrl result', result)
+
         return result;
     }
 };

--- a/assets/js/queryService.js
+++ b/assets/js/queryService.js
@@ -87,10 +87,13 @@ export default {
      */
 	
     getFormUrl: function(resultType, queryParams) {
+        console.log('getFormUrl resultType', resultType)
+        console.log('getFormUrl queryParams', queryParams)
         var result = Config.QUERY_URLS[resultType];
         if (queryParams) {
             result = result + '?' + queryParams;
         }
+        console.log('getFormUrl result', result)
         return result;
     }
 };

--- a/assets/js/store/store.js
+++ b/assets/js/store/store.js
@@ -5,6 +5,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
+    resultType: 'Station',
     countrySelectedState: [],
     countryOptionsState: [],
     stateSelectedState: [],
@@ -31,6 +32,9 @@ export default new Vuex.Store({
     taxOptionsState: {},
   },
   mutations: {
+    updateResultType(state, newResultType) {
+      state.resultType = newResultType;
+    },
     getCountryState(state, selected) {
       state.countrySelectedState = selected;
     },
@@ -105,6 +109,7 @@ export default new Vuex.Store({
     },
   },
   getters: {
+    resultType: (state) => state.resultType,
     countrySelectedState: (state) => state.countrySelectedState,
     countryOptionsState: (state) => state.countryOptionsState,
     stateSelectedState: (state) => state.stateSelectedState,

--- a/assets/js/store/store.js
+++ b/assets/js/store/store.js
@@ -5,7 +5,6 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    resultType: 'Station',
     countrySelectedState: [],
     countryOptionsState: [],
     stateSelectedState: [],
@@ -32,9 +31,6 @@ export default new Vuex.Store({
     taxOptionsState: {},
   },
   mutations: {
-    updateResultType(state, newResultType) {
-      state.resultType = newResultType;
-    },
     getCountryState(state, selected) {
       state.countrySelectedState = selected;
     },
@@ -109,7 +105,6 @@ export default new Vuex.Store({
     },
   },
   getters: {
-    resultType: (state) => state.resultType,
     countrySelectedState: (state) => state.countrySelectedState,
     countryOptionsState: (state) => state.countryOptionsState,
     stateSelectedState: (state) => state.stateSelectedState,
@@ -134,5 +129,5 @@ export default new Vuex.Store({
     assemblageOptionsState: (state) => state.assemblageOptionsState,
     taxSelectedState: (state) => state.taxSelectedState,
     taxOptionsState: (state) => state.taxOptionsState
-  },
+  }
 })

--- a/assets/js/views/DataDetailsView.vue
+++ b/assets/js/views/DataDetailsView.vue
@@ -3,7 +3,6 @@
 
 <script>
 import { setEnabled, initializeInput, getAnchorQueryValues } from '../utils';
-import store from '../store/store.js';
 
 /*
  * Manages the data detail inputs view
@@ -102,7 +101,6 @@ export default {
                 }
 
                 self.updateResultTypeAction(resultType);
-                store.commit('updateResultType', resultType);
             };
         })
 

--- a/assets/js/views/DataDetailsView.vue
+++ b/assets/js/views/DataDetailsView.vue
@@ -3,7 +3,7 @@
 
 <script>
 import { setEnabled, initializeInput, getAnchorQueryValues } from '../utils';
-
+import store from '../store/store.js';
 
 /*
  * Manages the data detail inputs view
@@ -19,7 +19,16 @@ import { setEnabled, initializeInput, getAnchorQueryValues } from '../utils';
 
 export default {
   name: "DataDetailsView",
-  props: ['container', 'updateResultTypeAction'],
+  props: {
+    container: {
+      type: HTMLDivElement,
+      required: true
+    },
+    updateResultTypeAction: {
+      type: Function,
+      required: true
+    }
+  },
   methods: {
         /*
      * Initializes the widgets and sets up the DOM event handlers.
@@ -93,8 +102,8 @@ export default {
                 }
 
                 self.updateResultTypeAction(resultType);
+                store.commit('updateResultType', resultType);
             };
-
         })
 
         sorted.onchange = function () {
@@ -127,9 +136,9 @@ export default {
         });
     },
     getResultType() {
-        if(document.querySelector('input.result-type:checked') !== null){
+        if (document.querySelector('input.result-type:checked') !== null) {
             return document.querySelector('input.result-type:checked').value;
-        }else{
+        } else {
             return null;
         }
     },

--- a/assets/js/views/DataDetailsView.vue
+++ b/assets/js/views/DataDetailsView.vue
@@ -54,11 +54,11 @@ export default {
             mimeTypeInitValues.push(getAnchorQueryValues(radiobox.getAttribute('name')));
         });
 
-        mimeTypeInitValues.forEach(function(item){
+        mimeTypeInitValues.forEach(function(item) {
             if (item.length) {
                 document.querySelector(`input[value="${item[0]}"]`).checked = true;
             }
-        })
+        });
 
         mimeTypeRadioboxes.forEach(function(radiobox){
             radiobox.onclick = () => {

--- a/assets/js/views/DownloadFormView.vue
+++ b/assets/js/views/DownloadFormView.vue
@@ -55,7 +55,7 @@ export default {
     providers: {
       type: Object,
       required: true
-    },
+    }
   },
   data () {
     return {
@@ -174,12 +174,20 @@ export default {
             propsData: {
                 container : this.form.querySelector('.download-box-input-div'),
                 updateResultTypeAction : (resultType) => {
-                  const basicForm = document.querySelector('#paramsBasic');
+                  // Change the 'form action' on both the basic and advanced forms everytime the 'Data Profiles'
+                  // radio buttons are changed. This keeps the form action correctly selected when the basic form
+                  // 'id=params-basic' is selected. This is acceptable behavior because the 'form action' attribute
+                  // only accepts the URL and not the URL parameters. The URL parameters are only for the pre-download
+                  // query which reports the number of database entries that will be returned. The actual data download is
+                  // accomplished through the form action which sends the form data to a URL that changes depending on
+                  // the 'Data Profile' selected. For example, the default form action attribute value is
+                  // 'https://www.waterqualitydata.us/data/Station/search', if the user would change the radio buttons
+                  // for the 'Data Profiles' to 'Project' the form action attribute value would be
+                  // 'https://www.waterqualitydata.us/data/Project/search'.
+                  const basicForm = document.querySelector('#params-basic');
                   const advancedForm = document.querySelector('#params');
-                  console.log('ran updateResultTypeAction with resultType ', resultType)
-                    // this.form.setAttribute('action', queryService.getFormUrl(resultType));
-                    advancedForm.setAttribute('action', queryService.getFormUrl(resultType));
-                    basicForm.setAttribute('action', queryService.getFormUrl(resultType));
+                  basicForm.setAttribute('action', queryService.getFormUrl(resultType));
+                  advancedForm.setAttribute('action', queryService.getFormUrl(resultType));
                 }
             }
         });
@@ -381,9 +389,7 @@ export default {
             const resultType = this.dataDetailsView.getResultType();
             const queryParamArray = this.getQueryParamArray(form);
             const queryString = decodeURIComponent(getQueryString(queryParamArray));
-console.log('queryString ', queryString)
-            let self = this;
-console.log('form ', form)
+            const self = this;
             const startDownload = (totalCount) => {
                 window._gaq.push([
                     '_trackEvent',
@@ -502,9 +508,9 @@ console.log('form ', form)
         return result;
     },
 
-    // getResultType() {
-    //     return this.dataDetailsView.getResultType();
-    // }
-  },
+    getResultType() {
+        return this.dataDetailsView.getResultType();
+    }
+  }
 }
 </script>

--- a/assets/js/views/DownloadFormView.vue
+++ b/assets/js/views/DownloadFormView.vue
@@ -39,7 +39,24 @@ let portalViews = new portalViewClass();
  */
 export default {
   name: "DownloadFormView",
-  props: ['form', 'downloadProgressDialog', 'downloadProgressDialogBasic', "providers"],
+  props: {
+    form: {
+      type: HTMLFormElement,
+      required: true
+    },
+    downloadProgressDialog: {
+      type: Object,
+      required: true
+    },
+    downloadProgressDialogBasic: {
+      type: Object,
+      required: true
+    },
+    providers: {
+      type: Object,
+      required: true
+    },
+  },
   data () {
     return {
       selectedForm: document.querySelector('#paramsBasic')
@@ -157,7 +174,7 @@ export default {
             propsData: {
                 container : this.form.querySelector('.download-box-input-div'),
                 updateResultTypeAction : (resultType) => {
-                    this.form.getAttribute('action', queryService.getFormUrl(resultType));
+                    this.form.setAttribute('action', queryService.getFormUrl(resultType));
                 }
             }
         });
@@ -481,9 +498,9 @@ export default {
         return result;
     },
 
-    getResultType() {
-        return this.dataDetailsView.getResultType();
-    }
+    // getResultType() {
+    //     return this.dataDetailsView.getResultType();
+    // }
   },
 }
 </script>

--- a/assets/js/views/DownloadFormView.vue
+++ b/assets/js/views/DownloadFormView.vue
@@ -174,7 +174,12 @@ export default {
             propsData: {
                 container : this.form.querySelector('.download-box-input-div'),
                 updateResultTypeAction : (resultType) => {
-                    this.form.setAttribute('action', queryService.getFormUrl(resultType));
+                  const basicForm = document.querySelector('#paramsBasic');
+                  const advancedForm = document.querySelector('#params');
+                  console.log('ran updateResultTypeAction with resultType ', resultType)
+                    // this.form.setAttribute('action', queryService.getFormUrl(resultType));
+                    advancedForm.setAttribute('action', queryService.getFormUrl(resultType));
+                    basicForm.setAttribute('action', queryService.getFormUrl(resultType));
                 }
             }
         });
@@ -361,7 +366,7 @@ export default {
         let formType;
         let buttonSelector;
         let downloadProgressDialog;
-        if (form.id == "params") {
+        if (form.id === "params") {
             formType = "advanced";
             buttonSelector = "#main-button";
             downloadProgressDialog = this.downloadProgressDialog;
@@ -376,9 +381,9 @@ export default {
             const resultType = this.dataDetailsView.getResultType();
             const queryParamArray = this.getQueryParamArray(form);
             const queryString = decodeURIComponent(getQueryString(queryParamArray));
-
+console.log('queryString ', queryString)
             let self = this;
-
+console.log('form ', form)
             const startDownload = (totalCount) => {
                 window._gaq.push([
                     '_trackEvent',
@@ -386,7 +391,6 @@ export default {
                     self.dataDetailsView.getResultType() + 'Download',
                     queryString,
                     parseInt(totalCount)]);
-
                 form.submit();
             };
 

--- a/assets/js/views/ShowAPIView.vue
+++ b/assets/js/views/ShowAPIView.vue
@@ -26,6 +26,10 @@ export default {
     getQueryParamArray: {
       type: Function,
       required: true
+    },
+    getResultType: {
+      type: Function,
+      requried: true
     }
   },
   methods: {
@@ -38,8 +42,7 @@ export default {
         let wfsText = this.container.querySelector('#getfeature-query-div textarea');
 
         const showServiceCallsHandler = () => {
-          console.log('in showapi store resultType', store.state.resultType)
-            let resultType = store.state.resultType;
+            let resultType = this.getResultType();
             let queryParamArray = this.getQueryParamArray(this.container.closest("form"));
             const queryParamsWithoutCSRFToken = queryParamArray.filter( param => param.name !== 'csrf_token' );
             let apiQueryString;

--- a/assets/js/views/ShowAPIView.vue
+++ b/assets/js/views/ShowAPIView.vue
@@ -18,7 +18,16 @@ import store from '../store/store.js';
 
 export default {
   name: "ShowAPIView",
-  props: ['container', 'getQueryParamArray', 'getResultType'],
+  props: {
+    container: {
+      type: HTMLDivElement,
+      required: true
+    },
+    getQueryParamArray: {
+      type: Function,
+      required: true
+    }
+  },
   methods: {
     initialize() {
         this.showAPIViewVisible = false;
@@ -29,23 +38,24 @@ export default {
         let wfsText = this.container.querySelector('#getfeature-query-div textarea');
 
         const showServiceCallsHandler = () => {
-            let resultType = this.getResultType();
+          console.log('in showapi store resultType', store.state.resultType)
+            let resultType = store.state.resultType;
             let queryParamArray = this.getQueryParamArray(this.container.closest("form"));
             const queryParamsWithoutCSRFToken = queryParamArray.filter( param => param.name !== 'csrf_token' );
             let apiQueryString;
             let curlString;
-            if (resultType !== null){
+            if (resultType !== null) {
                 apiQueryString = queryService.getFormUrl(resultType, getQueryString(queryParamsWithoutCSRFToken));
                 curlString = getCurlString(resultType, queryParamsWithoutCSRFToken);
-            }else{
+            } else {
                 apiQueryString = queryService.getFormUrl("Station", getQueryString(queryParamsWithoutCSRFToken));
                 curlString = getCurlString("Station", queryParamsWithoutCSRFToken);
             }
 
             apiQueryDiv.style.display = 'block';
-            if(resultType !== null){
+            if(resultType !== null) {
                 apiQueryTitle.innerHTML = resultType.replace(/([A-Z])/g, ' $1');
-            }else{
+            } else {
                 apiQueryTitle.innerHTML = 'Station';
             }
             apiQueryText.innerHTML = apiQueryString;

--- a/assets/scss/custom/custom.scss
+++ b/assets/scss/custom/custom.scss
@@ -15,6 +15,12 @@ body {
 
   #forms {
     @include u-padding-top('205');
+    .usa-button {
+      @include at-media-max('desktop') {
+        @include u-margin-bottom(1);
+      }
+    }
+
     // Home Page form intro
     #formIntro {
       @include u-margin-bottom('205');
@@ -28,6 +34,9 @@ body {
         @include u-padding('205');
 
         .footer-flex {
+          .usa-button {
+            @include u-margin-top(1);
+          }
           @include u-display('flex');
           @include u-flex('column');
           @include u-flex('justify-center');

--- a/assets/scss/partials/_portal-form.scss
+++ b/assets/scss/partials/_portal-form.scss
@@ -1,3 +1,7 @@
+#nldi-container {
+  @include u-padding-top(1);
+}
+
 .wqp-multiselect {
   .multiselect__tags {
     @include u-border-width('1px');
@@ -49,6 +53,9 @@
       @include u-display('flex');
       @include u-flex('column');
       @include u-flex('justify-end');
+      @include at-media-max('desktop') {
+        @include u-margin-top(2);
+      }
     }
     #point-location-basic-label {
       @include u-display('flex');
@@ -138,6 +145,5 @@
       width: 100%;
       @include u-padding-top('105');
     }
-
   }
 }

--- a/server/wqp/portal_ui_blueprint/templates/index.html
+++ b/server/wqp/portal_ui_blueprint/templates/index.html
@@ -139,8 +139,7 @@
                       <input class="usa-input" type="text" name="long"
                         placeholder="0" id="longBasic" aria-label="Point longitude"/>
                     </div>
-                    <div id="useMyLocationBasic"></div><!-- <button id="useMyLocationBasic"
-                      class="usa-button usa-button--outline" type="button">Use my location</button> -->
+                    <div id="useMyLocationBasic"></div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Title WQP-1782 Only Site Profile is Downloading
-----------
When using the 'basic' form, all the downloads were for 'station' regardless of the 'Data Profile' chosen.  This corrects that change.

Description
-----------
The root of the problem is that the form has two instances (basic and advanced) and only the 'advanced' instance form action attribute was getting updated when the Data Profile radio button was changed. After trying many options, I opted to simply change the form action attribute on both forms at the same time to the same form action. Since the form action is the same for both forms. 
  

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
