### PR TITLE
Wqp 1795 - Fixed how clear buttons work on forms

### DIFF
--- a/assets/js/DownloadFormController.vue
+++ b/assets/js/DownloadFormController.vue
@@ -92,11 +92,12 @@ export default {
       validateDownloadForm(form, formType) {
         // Validate download form. If invalid show validate dialog with error message and return false.
         // Otherwise return true
-
+        // TODO: This code does not work in part because there is no #validate-download-dialog element.
+        // Also basic field validation is no longer occuring.
         var validateModalEl = document.querySelector('#validate-download-dialog');
         var showModal = function (message) {
             validateModalEl.querySelector('.modal-body').innerHTML = message;
-            validateModalEl.style.display = "block";
+            validateModalEl.style.display = 'block';
         };
 
         // Check to see if any input validation error messages exist
@@ -107,7 +108,7 @@ export default {
 
         var result;
         //  Advanced form validation
-        if(formType == "advanced"){
+        if (formType == "advanced") {
             result = this.validatePointLocation({
                 withinEl: form.querySelector('#within'),
                 latEl: form.querySelector('#lat'),

--- a/assets/js/store/store.js
+++ b/assets/js/store/store.js
@@ -28,7 +28,7 @@ export default new Vuex.Store({
     assemblageSelectedState: [],
     assemblageOptionsState: [],
     taxSelectedState: [],
-    taxOptionsState: {},
+    taxOptionsState: {}
   },
   mutations: {
     getCountryState(state, selected) {

--- a/assets/js/views/DownloadFormView.vue
+++ b/assets/js/views/DownloadFormView.vue
@@ -1,5 +1,3 @@
-<template>
-</template>
 
 <script>
 import Vue from 'vue';
@@ -10,7 +8,6 @@ import DataDetailsView from './DataDetailsView.vue';
 import NldiView from './NldiView.vue';
 import PlaceInputView from './PlaceInputView.vue';
 import PointLocationInputView from './PointLocationInputView.vue';
-import PortalViews from './PortalViews.vue';
 import SamplingParameterInputView from './SamplingParameterInputView.vue';
 import SiteParameterInputView from './SiteParameterInputView.vue';
 import CachedCodesModel from '../CachedCodesModel.vue';
@@ -59,20 +56,6 @@ export default {
       selectedForm: document.querySelector('#params-basic')
     };
   },
-  components: {
-    DownloadFormController,
-    SamplingParameterInputView,
-    NldiView,
-    PlaceInputView,
-    BiologicalSamplingInputView,
-    BoundingBoxInputView,
-    SiteParameterInputView,
-    PointLocationInputView,
-    DataDetailsView,
-    CachedCodesModel,
-    CodesWithKeysModel,
-    PortalViews
-  },
   methods: {
     /*
      * @return {PlaceInputView}
@@ -90,7 +73,7 @@ export default {
 
       const countryModel = new cachedCodesClass({
         propsData: {
-          codes: 'countrycode',
+          codes: 'countrycode'
         }
       });
       const stateModel = new codesWithKeysClass({
@@ -205,7 +188,7 @@ export default {
       boundingBoxInputView.initialize();
 
       // Only create map for advanced form
-      if (Config.NLDI_ENABLED && this.form.getAttribute('id') == "params") {
+      if (Config.NLDI_ENABLED && this.form.getAttribute('id') === 'params') {
         let nldiClass = Vue.extend(NldiView);
         const nldiView = new nldiClass({
           propsData: {
@@ -214,9 +197,9 @@ export default {
           }
         });
         nldiView.initialize();
-      } else if (this.form.getAttribute('id') == "params") {
-        this.form.querySelector('#nldi-container').style.display = "none";
-        this.form.querySelector('#nldi-map').style.display = "none";
+      } else if (this.form.getAttribute('id') === 'params') {
+        this.form.querySelector('#nldi-container').style.display = 'none';
+        this.form.querySelector('#nldi-map').style.display = 'none';
       }
 
 
@@ -426,35 +409,37 @@ export default {
      */
     getQueryParamArray(currentForm) {
       let stores = [
-        {name: "countrycode", value: store.state.countrySelectedState},
-        {name: "statecode", value: store.state.stateSelectedState},
-        {name: "countycode", value: store.state.countySelectedState},
-        {name: "siteType", value: store.state.sitetypeSelectedState},
-        {name: "charGroup", value: store.state.chargroupSelectedState},
-        {name: "sampleMedia", value: store.state.sampleMediaSelectedState},
-        {name: "organization", value: store.state.orgIDSelectedState},
-        {name: "project", value: store.state.projIDSelectedState},
-        {name: "siteid", value: store.state.siteIDSelectedState},
-        {name: "characteristicName", value: store.state.charSelectedState},
-        {name: "assemblage", value: store.state.assemblageSelectedState},
-        {name: "subjectTaxonomicName", value: store.state.taxSelectedState}
+        {name: 'countrycode', value: store.state.countrySelectedState},
+        {name: 'statecode', value: store.state.stateSelectedState},
+        {name: 'countycode', value: store.state.countySelectedState},
+        {name: 'siteType', value: store.state.sitetypeSelectedState},
+        {name: 'charGroup', value: store.state.chargroupSelectedState},
+        {name: 'sampleMedia', value: store.state.sampleMediaSelectedState},
+        {name: 'organization', value: store.state.orgIDSelectedState},
+        {name: 'project', value: store.state.projIDSelectedState},
+        {name: 'siteid', value: store.state.siteIDSelectedState},
+        {name: 'characteristicName', value: store.state.charSelectedState},
+        {name: 'assemblage', value: store.state.assemblageSelectedState},
+        {name: 'subjectTaxonomicName', value: store.state.taxSelectedState}
       ];
 
       // Need to eliminate form parameters within the mapping-div
-      const formInputs = currentForm.querySelectorAll('input:not(#mapping-div input, #nldi-map input, input[name="dataProfile"]), textarea:not(#mapping-div textarea, #nldi-map textarea), select:not(#mapping-div select, #nldi-map select), button:not(#mapping-div button, #nldi-map button');
+      const formInputs =
+          currentForm.querySelectorAll(
+              'input:not(#mapping-div input, #nldi-map input, input[name="dataProfile"]), textarea:not(#mapping-div textarea, #nldi-map textarea), select:not(#mapping-div select, #nldi-map select), button:not(#mapping-div button, #nldi-map button)'
+          );
       let result = [];
       let providersArray = [];
-      var length = formInputs.length;
       formInputs.forEach(function (el, index) {
         let multiselectArray = [];
-        if (el.type != 'radio' || el.checked || (el.className === 'datasources usa-checkbox__input')) {
+        if (el.type != 'radio' || el.checked || el.className === 'datasources usa-checkbox__input') {
           if (el.name != 'dataProfile') {
             const value = el.value;
             const valueIsNotEmpty = typeof value === 'string' ? value : value.length > 0;
             const name = el.getAttribute('name');
             if (valueIsNotEmpty && name && el.className != 'multiselect__input' && el.className != 'hidden-input') {
-              if ((valueIsNotEmpty && el.className === 'datasources usa-checkbox__input') && (el.checked === true)) {
-                providersArray.push(value)
+              if (valueIsNotEmpty && el.className === 'datasources usa-checkbox__input' && el.checked === true) {
+                providersArray.push(value);
               } else if (el.className !== 'datasources usa-checkbox__input') {
                 result.push({
                   name: name,
@@ -463,12 +448,12 @@ export default {
                 });
               }
             }
-            if (index === (length - 1)) {
+            if (index === formInputs.length - 1) {
               result.push({
                 name: 'providers',
                 value: providersArray,
                 multiple: el.dataset.multiple ? true : false
-              })
+              });
             } else if (el.className === 'hidden-input') {
               stores.forEach(function (state) {
                 if (el.name === state.name) {
@@ -481,7 +466,7 @@ export default {
                       name: state.name,
                       value: multiselectArray,
                       multiple: el.dataset.multiple ? true : false
-                    })
+                    });
                   }
                 }
               });
@@ -496,5 +481,5 @@ export default {
       return this.dataDetailsView.getResultType();
     }
   }
-}
+};
 </script>

--- a/assets/js/views/DownloadFormView.vue
+++ b/assets/js/views/DownloadFormView.vue
@@ -25,9 +25,6 @@ let downloadFormController = new downloadFormControllerClass();
 let cachedCodesClass = Vue.extend(CachedCodesModel);
 let codesWithKeysClass = Vue.extend(CodesWithKeysModel);
 
-let portalViewClass = Vue.extend(PortalViews);
-let portalViews = new portalViewClass();
-
 /*
  * Initializes the download form and provides methods to get information from the form
  * @param {Object} options
@@ -38,7 +35,7 @@ let portalViews = new portalViewClass();
  *      @func getQueryParams
  */
 export default {
-  name: "DownloadFormView",
+  name: 'DownloadFormView',
   props: {
     form: {
       type: HTMLFormElement,
@@ -57,69 +54,69 @@ export default {
       required: true
     }
   },
-  data () {
+  data() {
     return {
       selectedForm: document.querySelector('#params-basic')
-    }
+    };
   },
   components: {
-      DownloadFormController,
-      SamplingParameterInputView,
-      NldiView,
-      PlaceInputView,
-      BiologicalSamplingInputView,
-      BoundingBoxInputView,
-      SiteParameterInputView,
-      PointLocationInputView,
-      DataDetailsView,
-      CachedCodesModel,
-      CodesWithKeysModel,
-      PortalViews
+    DownloadFormController,
+    SamplingParameterInputView,
+    NldiView,
+    PlaceInputView,
+    BiologicalSamplingInputView,
+    BoundingBoxInputView,
+    SiteParameterInputView,
+    PointLocationInputView,
+    DataDetailsView,
+    CachedCodesModel,
+    CodesWithKeysModel,
+    PortalViews
   },
   methods: {
     /*
      * @return {PlaceInputView}
      */
     getPlaceInputView() {
-        let self = this;
-        // Initialize Place inputs
-        const getCountryFromState = function(id) {
-            return id ? id.split(':')[0] : '';
-        };
-        const getStateFromCounty = function(id) {
-            let ids = id.split(':');
-            return ids.length > 1 ? ids[0] + ':' + ids[1] : '';
-        };
+      let self = this;
+      // Initialize Place inputs
+      const getCountryFromState = function (id) {
+        return id ? id.split(':')[0] : '';
+      };
+      const getStateFromCounty = function (id) {
+        let ids = id.split(':');
+        return ids.length > 1 ? ids[0] + ':' + ids[1] : '';
+      };
 
-        const countryModel = new cachedCodesClass({
-            propsData: {
-                codes : 'countrycode',
-            }
-        });
-        const stateModel = new codesWithKeysClass({
-            propsData: {
-                codes : 'statecode',
-                keyParameter : 'countrycode',
-                parseKey : getCountryFromState
-            }
-        });
-        const countyModel = new codesWithKeysClass({
-            propsData: {
-                codes : 'countycode',
-                keyParameter : 'statecode',
-                parseKey : getStateFromCounty
-            }
-        });
-        let placeInputViewClass = Vue.extend(PlaceInputView);
-            return new placeInputViewClass({
-                propsData: {
-                    container : document.querySelector('#place'),
-                    countryModel : countryModel,
-                    stateModel : stateModel,
-                    countyModel : countyModel,
-                    providers: self.providers
-                }
-            });
+      const countryModel = new cachedCodesClass({
+        propsData: {
+          codes: 'countrycode',
+        }
+      });
+      const stateModel = new codesWithKeysClass({
+        propsData: {
+          codes: 'statecode',
+          keyParameter: 'countrycode',
+          parseKey: getCountryFromState
+        }
+      });
+      const countyModel = new codesWithKeysClass({
+        propsData: {
+          codes: 'countycode',
+          keyParameter: 'statecode',
+          parseKey: getStateFromCounty
+        }
+      });
+      let placeInputViewClass = Vue.extend(PlaceInputView);
+      return new placeInputViewClass({
+        propsData: {
+          container: document.querySelector('#place'),
+          countryModel: countryModel,
+          stateModel: stateModel,
+          countyModel: countyModel,
+          providers: self.providers
+        }
+      });
     },
 
     /*
@@ -129,299 +126,287 @@ export default {
      *      @resolve - if all initialization including successful fetches are complete
      *      @reject - if any fetches failed.
      */
-     initialize() {
-        const placeInputView = this.getPlaceInputView();
-        let pointLocationInputClass = Vue.extend(PointLocationInputView);
-        const pointLocationInputView = new pointLocationInputClass({
-            propsData: {
-                container : this.form.querySelector('#point-location')
-            }
-        });
-        let boundingBoxInputClass = Vue.extend(BoundingBoxInputView);
-        const boundingBoxInputView = new boundingBoxInputClass({
-            propsData: {
-                container : this.form.querySelector('#bounding-box')
-            }
-        });
-        let siteParameterInputClass = Vue.extend(SiteParameterInputView);
-        const siteParameterInputView = new siteParameterInputClass({
-            propsData: {
-                container : this.form.querySelector('#site-params'),
-                siteTypeModel : new cachedCodesClass({propsData: {codes : 'sitetype'}}),
-                organizationModel : new cachedCodesClass({propsData: {codes : 'organization'}}),
-                providers: this.providers
-            }
-        });
-        let samplingParametersClass = Vue.extend(SamplingParameterInputView);
-        const samplingParametersInputView = new samplingParametersClass({
-            propsData: {
-                container : this.form.querySelector('#sampling'),
-                sampleMediaModel : new cachedCodesClass({propsData: {codes: 'samplemedia'}}),
-                characteristicTypeModel : new cachedCodesClass({propsData: {codes: 'characteristictype'}}),
-                providers: this.providers
-            }
-        });
-        let biologicalSamplingInputClass = Vue.extend(BiologicalSamplingInputView);
-        const biologicalSamplingInputView = new biologicalSamplingInputClass({
-            propsData: {
-                container : this.form.querySelector('#biological'),
-                assemblageModel : new cachedCodesClass({propsData: {codes: 'assemblage'}}),
-                providers: this.providers
-            }
-        });
-        let dataDetailsClass = Vue.extend(DataDetailsView);
-        this.dataDetailsView = new dataDetailsClass({
-            propsData: {
-                container : this.form.querySelector('.download-box-input-div'),
-                updateResultTypeAction : (resultType) => {
-                  // Change the 'form action' on both the basic and advanced forms everytime the 'Data Profiles'
-                  // radio buttons are changed. This keeps the form action correctly selected when the basic form
-                  // 'id=params-basic' is selected. This is acceptable behavior because the 'form action' attribute
-                  // only accepts the URL and not the URL parameters. The URL parameters are only for the pre-download
-                  // query which reports the number of database entries that will be returned. The actual data download is
-                  // accomplished through the form action which sends the form data to a URL that changes depending on
-                  // the 'Data Profile' selected. For example, the default form action attribute value is
-                  // 'https://www.waterqualitydata.us/data/Station/search', if the user would change the radio buttons
-                  // for the 'Data Profiles' to 'Project' the form action attribute value would be
-                  // 'https://www.waterqualitydata.us/data/Project/search'.
-                  const basicForm = document.querySelector('#params-basic');
-                  const advancedForm = document.querySelector('#params');
-                  basicForm.setAttribute('action', queryService.getFormUrl(resultType));
-                  advancedForm.setAttribute('action', queryService.getFormUrl(resultType));
-                }
-            }
-        });
-
-        // Initialize form sub view
-        const initPlaceInputView = placeInputView.initialize();
-        const initSiteParameterInputView = siteParameterInputView.initialize();
-        const initSamplingParametersInputView = samplingParametersInputView.initialize();
-        const initBiologicalSamplingInputInputView = biologicalSamplingInputView.initialize();
-        let initComplete = Promise.all([
-            initBiologicalSamplingInputInputView,
-            initPlaceInputView,
-            initSamplingParametersInputView,
-            initSiteParameterInputView]);
-
-        this.dataDetailsView.initialize();
-        pointLocationInputView.initialize();
-        boundingBoxInputView.initialize();
-
-        // Only create map for advanced form
-        if (Config.NLDI_ENABLED && this.form.getAttribute('id') == "params") {
-            let nldiClass = Vue.extend(NldiView);
-            const nldiView = new nldiClass({
-                propsData: {
-                    mapDivId : 'nldi-map',
-                    input: 'nldi-url'
-                }
-            });
-            nldiView.initialize(); 
-        } else if (this.form.getAttribute('id') == "params"){
-            this.form.querySelector('#nldi-container').style.display = "none";
-            this.form.querySelector('#nldi-map').style.display = "none";
+    initialize() {
+      const placeInputView = this.getPlaceInputView();
+      let pointLocationInputClass = Vue.extend(PointLocationInputView);
+      const pointLocationInputView = new pointLocationInputClass({
+        propsData: {
+          container: this.form.querySelector('#point-location')
         }
+      });
+      let boundingBoxInputClass = Vue.extend(BoundingBoxInputView);
+      const boundingBoxInputView = new boundingBoxInputClass({
+        propsData: {
+          container: this.form.querySelector('#bounding-box')
+        }
+      });
+      let siteParameterInputClass = Vue.extend(SiteParameterInputView);
+      const siteParameterInputView = new siteParameterInputClass({
+        propsData: {
+          container: this.form.querySelector('#site-params'),
+          siteTypeModel: new cachedCodesClass({propsData: {codes: 'sitetype'}}),
+          organizationModel: new cachedCodesClass({propsData: {codes: 'organization'}}),
+          providers: this.providers
+        }
+      });
+      let samplingParametersClass = Vue.extend(SamplingParameterInputView);
+      const samplingParametersInputView = new samplingParametersClass({
+        propsData: {
+          container: this.form.querySelector('#sampling'),
+          sampleMediaModel: new cachedCodesClass({propsData: {codes: 'samplemedia'}}),
+          characteristicTypeModel: new cachedCodesClass({propsData: {codes: 'characteristictype'}}),
+          providers: this.providers
+        }
+      });
+      let biologicalSamplingInputClass = Vue.extend(BiologicalSamplingInputView);
+      const biologicalSamplingInputView = new biologicalSamplingInputClass({
+        propsData: {
+          container: this.form.querySelector('#biological'),
+          assemblageModel: new cachedCodesClass({propsData: {codes: 'assemblage'}}),
+          providers: this.providers
+        }
+      });
+      let dataDetailsClass = Vue.extend(DataDetailsView);
+      this.dataDetailsView = new dataDetailsClass({
+        propsData: {
+          container: this.form.querySelector('.download-box-input-div'),
+          updateResultTypeAction: (resultType) => {
+            // Change the 'form action' on both the basic and advanced forms everytime the 'Data Profiles'
+            // radio buttons are changed. This keeps the form action correctly selected when the basic form
+            // 'id=params-basic' is selected. This is acceptable behavior because the 'form action' attribute
+            // only accepts the URL and not the URL parameters. The URL parameters are only for the pre-download
+            // query which reports the number of database entries that will be returned. The actual data download is
+            // accomplished through the form action which sends the form data to a URL that changes depending on
+            // the 'Data Profile' selected. For example, the default form action attribute value is
+            // 'https://www.waterqualitydata.us/data/Station/search', if the user would change the radio buttons
+            // for the 'Data Profiles' to 'Project' the form action attribute value would be
+            // 'https://www.waterqualitydata.us/data/Project/search'.
+            const basicForm = document.querySelector('#params-basic');
+            const advancedForm = document.querySelector('#params');
+            basicForm.setAttribute('action', queryService.getFormUrl(resultType));
+            advancedForm.setAttribute('action', queryService.getFormUrl(resultType));
+          }
+        }
+      });
 
+      // Initialize form sub view
+      const initPlaceInputView = placeInputView.initialize();
+      const initSiteParameterInputView = siteParameterInputView.initialize();
+      const initSamplingParametersInputView = samplingParametersInputView.initialize();
+      const initBiologicalSamplingInputInputView = biologicalSamplingInputView.initialize();
+      let initComplete = Promise.all([
+        initBiologicalSamplingInputInputView,
+        initPlaceInputView,
+        initSamplingParametersInputView,
+        initSiteParameterInputView]);
 
-        // Initialize the share window and button event handler
-        const shareContainer = this.form.querySelector('.share-container');
-        const shareText = shareContainer.querySelector('textarea');
-        shareText.value = window.location.href;
-        
-        let self = this;
-        document.querySelector('#basic-tab').addEventListener('click', function(){
-            let formtype = document.querySelector('#params-basic');
-            self.updateSelected(formtype);
+      this.dataDetailsView.initialize();
+      pointLocationInputView.initialize();
+      boundingBoxInputView.initialize();
+
+      // Only create map for advanced form
+      if (Config.NLDI_ENABLED && this.form.getAttribute('id') == "params") {
+        let nldiClass = Vue.extend(NldiView);
+        const nldiView = new nldiClass({
+          propsData: {
+            mapDivId: 'nldi-map',
+            input: 'nldi-url'
+          }
         });
+        nldiView.initialize();
+      } else if (this.form.getAttribute('id') == "params") {
+        this.form.querySelector('#nldi-container').style.display = "none";
+        this.form.querySelector('#nldi-map').style.display = "none";
+      }
 
-        document.querySelector('#advanced-tab').addEventListener('click', function(){
-            let formtype = document.querySelector('#params');
-            self.updateSelected(formtype);
-        });
 
-        this.setUpWatchers();
+      // Initialize the share window and button event handler
+      const shareContainer = this.form.querySelector('.share-container');
+      const shareText = shareContainer.querySelector('textarea');
+      shareText.value = window.location.href;
 
-        let basicForm = document.querySelector('#params-basic');
+      let self = this;
+      document.querySelector('#basic-tab').addEventListener('click', function () {
+        let formtype = document.querySelector('#params-basic');
+        self.updateSelected(formtype);
+      });
 
-        // Set up change event handler for form inputs to update the hash part of the url
-        let inputs = this.form.querySelectorAll('input[name], select[name], textarea[name], button[name]').forEach(input => {
-            input.onchange = () => {
-                const queryParamArray = this.getQueryParamArray(this.form);
-                const queryString = getQueryString(queryParamArray, ['zip', 'csrf_token']);
-                window.location.hash = `#${queryString}`;
-                shareText.value = window.location.href;
-            };
-        });
-        let basicInputs = basicForm.querySelectorAll('input[name], select[name], textarea[name], button[name]').forEach(input => {
-            input.onchange = () => {
-                const queryParamArray = this.getQueryParamArray(basicForm);
-                const queryString = getQueryString(queryParamArray, ['zip', 'csrf_token']);
-                window.location.hash = `#${queryString}`;
-                shareText.value = window.location.href;
-            }
-        });
+      document.querySelector('#advanced-tab').addEventListener('click', function () {
+        let formtype = document.querySelector('#params');
+        self.updateSelected(formtype);
+      });
 
-        let dataProviders = this.form.querySelector('#providers-select');
-        // Add click handler for clear parameters button
-        basicForm.querySelector('.reset-params').onclick = () => {
-            document.querySelector('#withinBasic').value = '';
-            document.querySelector('#withinBasic').dispatchEvent(new Event('change'));
-            document.querySelector('#latBasic').value = '';
-            document.querySelector('#latBasic').dispatchEvent(new Event('change'));
-            document.querySelector('#longBasic').value = '';
-            document.querySelector('#longBasic').dispatchEvent(new Event('change'));
-            document.querySelector('#countrycodeBasic').value = null;
-            store.commit("getCountryState", []);
-            store.commit("getStateState", []);
-            store.commit("getCountyState", []);
-            store.commit("getSitetypeState", [])
-            placeInputView.resetContainer();
-            pointLocationInputView.resetContainer();
-            siteParameterInputView.resetContainer();
+      this.setUpWatchers();
+
+      const basicForm = document.querySelector('#params-basic');
+      // Set up change event handler for form inputs to update the hash part of the url
+      this.form.querySelectorAll('input[name], select[name], textarea[name], button[name]').forEach(input => {
+        input.onchange = () => {
+          const queryParamArray = this.getQueryParamArray(this.form);
+          const queryString = getQueryString(queryParamArray, ['zip', 'csrf_token']);
+          window.location.hash = `#${queryString}`;
+          shareText.value = window.location.href;
         };
-
-        // Add click handler for clear filters button
-        basicForm.querySelector('.reset-filters').onclick = () => {
-            document.querySelector('#startDateLoBasic').value = '';
-            document.querySelector('#startDateLoBasic').dispatchEvent(new Event('change'));
-            document.querySelector('#startDateHiBasic').value = '';
-            document.querySelector('#startDateHiBasic').dispatchEvent(new Event('change'));
-            let checkboxes = document.querySelector('.datasources-basic').querySelectorAll('input, select, button, textarea');
-            checkboxes.forEach(function(checkbox){
-                checkbox.checked = true;
-            });
-            store.commit("getSampleMediaState", []);
-            store.commit("getChargroupState", []);
-            samplingParametersInputView.resetContainer();
+      });
+      basicForm.querySelectorAll('input[name], select[name], textarea[name], button[name]').forEach(input => {
+        input.onchange = () => {
+          const queryParamArray = this.getQueryParamArray(basicForm);
+          const queryString = getQueryString(queryParamArray, ['zip', 'csrf_token']);
+          window.location.hash = `#${queryString}`;
+          shareText.value = window.location.href;
         };
+      });
 
-        basicForm.querySelector('#startOver').onclick = () => {
-            placeInputView.resetContainer();
-            pointLocationInputView.resetContainer();
-            boundingBoxInputView.resetContainer();
-            samplingParametersInputView.resetContainer();
-            siteParameterInputView.resetContainer();
-            this.dataDetailsView.resetContainer();
+      // Sets up clear form action for all clear search buttons
+      const dataDetailsView = this.dataDetailsView;
+      const clearButtons = document.querySelectorAll('.clear-form');
+      clearButtons.forEach((button) => {
+        button.onclick = () => {
+          // Clears basic form step 1
+          document.querySelector('#withinBasic').value = '';
+          document.querySelector('#withinBasic').dispatchEvent(new Event('change'));
+          document.querySelector('#latBasic').value = '';
+          document.querySelector('#latBasic').dispatchEvent(new Event('change'));
+          document.querySelector('#longBasic').value = '';
+          document.querySelector('#longBasic').dispatchEvent(new Event('change'));
+          store.commit('getCountryState', []);
+          store.commit('getStateState', []);
+          store.commit('getCountyState', []);
+          store.commit('getSitetypeState', []);
+
+          // Clears basic form step 2
+          const checkboxes = document.querySelector('.datasources-basic').querySelectorAll('input');
+          checkboxes.forEach(function (checkbox) {
+            checkbox.checked = true;
+          });
+          document.querySelector('#startDateLoBasic').value = '';
+          document.querySelector('#startDateLoBasic').dispatchEvent(new Event('change'));
+          document.querySelector('#startDateHiBasic').value = '';
+          document.querySelector('#startDateHiBasic').dispatchEvent(new Event('change'));
+          store.commit('getSampleMediaState', []);
+          store.commit('getChargroupState', []);
+
+          // Clears data details view on both basic and advanced
+          dataDetailsView.resetContainer();
+
+          // Clears all other data on advanced form
+          placeInputView.resetContainer();
+          pointLocationInputView.resetContainer();
+          boundingBoxInputView.resetContainer();
+          samplingParametersInputView.resetContainer();
+          siteParameterInputView.resetContainer();
         };
+      });
 
-        this.form.querySelector('#advancedStartOver').onclick = () => {
-            placeInputView.resetContainer();
-            pointLocationInputView.resetContainer();
-            boundingBoxInputView.resetContainer();
-            samplingParametersInputView.resetContainer();
-            siteParameterInputView.resetContainer();
-            this.dataDetailsView.resetContainer();
-        };
+      // // Set up the Download button for basic and advanced forms
+      this.setUpDownloadButton(basicForm);
+      this.setUpDownloadButton(this.form);
 
-        // // Set up the Download button for basic and advanced forms
-        this.setUpDownloadButton(basicForm);
-        this.setUpDownloadButton(this.form);
-
-        return initComplete;
+      return initComplete;
     },
     updateSelected(formtype) {
-        this.selectedForm = formtype;
+      this.selectedForm = formtype;
     },
-    setUpWatchers(){
-        const shareContainer = this.form.querySelector('.share-container');
-        const shareText = shareContainer.querySelector('textarea');
-        let self = this;
-        let getQuery = function(){
-            const queryParamArray = self.getQueryParamArray(self.selectedForm);
-            const queryString = getQueryString(queryParamArray, ['zip', 'csrf_token']);
-            window.location.hash = `#${queryString}`;
-            shareText.value = window.location.href;
-        }
+    setUpWatchers() {
+      const shareContainer = this.form.querySelector('.share-container');
+      const shareText = shareContainer.querySelector('textarea');
+      let self = this;
+      let getQuery = function () {
+        const queryParamArray = self.getQueryParamArray(self.selectedForm);
+        const queryString = getQueryString(queryParamArray, ['zip', 'csrf_token']);
+        window.location.hash = `#${queryString}`;
+        shareText.value = window.location.href;
+      };
 
-        store.watch(() => store.state.countrySelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.stateSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.countySelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.sitetypeSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.siteIDSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.projIDSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.orgIDSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.chargroupSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.sampleMediaSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.charSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.assemblageSelectedState, () => {
-            getQuery();
-        });
-        store.watch(() => store.state.taxSelectedState, () => {
-            getQuery();
-        });
+      store.watch(() => store.state.countrySelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.stateSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.countySelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.sitetypeSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.siteIDSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.projIDSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.orgIDSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.chargroupSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.sampleMediaSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.charSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.assemblageSelectedState, () => {
+        getQuery();
+      });
+      store.watch(() => store.state.taxSelectedState, () => {
+        getQuery();
+      });
     },
     setUpDownloadButton(form) {
-        let formType;
-        let buttonSelector;
-        let downloadProgressDialog;
-        if (form.id === "params") {
-            formType = "advanced";
-            buttonSelector = "#main-button";
-            downloadProgressDialog = this.downloadProgressDialog;
-        } else {
-            formType = "basic";
-            buttonSelector = "#basic-main-button";
-            downloadProgressDialog = this.downloadProgressDialogBasic;
-        }
-        // Set up the Download button
-        form.querySelector(buttonSelector).onclick = (event) => {
-            const fileFormat = this.dataDetailsView.getMimeType();
-            const resultType = this.dataDetailsView.getResultType();
-            const queryParamArray = this.getQueryParamArray(form);
-            const queryString = decodeURIComponent(getQueryString(queryParamArray));
-            const self = this;
-            const startDownload = (totalCount) => {
-                window._gaq.push([
-                    '_trackEvent',
-                    'Portal Page',
-                    self.dataDetailsView.getResultType() + 'Download',
-                    queryString,
-                    parseInt(totalCount)]);
-                form.submit();
-            };
-
-            event.preventDefault();
-            if (!downloadFormController.validateDownloadForm(form, formType)) {
-                console.log("invalid")
-                return;
-            }
-
-            window._gaq.push([
-                '_trackEvent',
-                'Portal Page',
-                resultType + 'Count',
-                queryString
-            ]);
-
-            downloadProgressDialog.show('download');
-            queryService.fetchQueryCounts(resultType, queryParamArray, this.providers.getIds())
-                .then((counts) => {
-                    downloadProgressDialog.updateProgress(counts, resultType, fileFormat, startDownload);
-                })
-                .catch((message) => {
-                    downloadProgressDialog.cancelProgress(message);
-                });
+      let formType;
+      let buttonSelector;
+      let downloadProgressDialog;
+      if (form.id === 'params') {
+        formType = 'advanced';
+        buttonSelector = '#main-button';
+        downloadProgressDialog = this.downloadProgressDialog;
+      } else {
+        formType = 'basic';
+        buttonSelector = '#basic-main-button';
+        downloadProgressDialog = this.downloadProgressDialogBasic;
+      }
+      // Set up the Download button
+      form.querySelector(buttonSelector).onclick = (event) => {
+        const fileFormat = this.dataDetailsView.getMimeType();
+        const resultType = this.dataDetailsView.getResultType();
+        const queryParamArray = this.getQueryParamArray(form);
+        const queryString = decodeURIComponent(getQueryString(queryParamArray));
+        const self = this;
+        const startDownload = (totalCount) => {
+          window._gaq.push([
+            '_trackEvent',
+            'Portal Page',
+            self.dataDetailsView.getResultType() + 'Download',
+            queryString,
+            parseInt(totalCount)]);
+          form.submit();
         };
+
+        event.preventDefault();
+        if (!downloadFormController.validateDownloadForm(form, formType)) {
+          console.log('Form is invalid');
+          return;
+        }
+
+        window._gaq.push([
+          '_trackEvent',
+          'Portal Page',
+          resultType + 'Count',
+          queryString
+        ]);
+
+        downloadProgressDialog.show('download');
+        queryService.fetchQueryCounts(resultType, queryParamArray, this.providers.getIds())
+            .then((counts) => {
+              downloadProgressDialog.updateProgress(counts, resultType, fileFormat, startDownload);
+            })
+            .catch((message) => {
+              downloadProgressDialog.cancelProgress(message);
+            });
+      };
     },
 
     /*
@@ -429,7 +414,7 @@ export default {
      * @return {Boolean}
      */
     validateDownloadForm() {
-        return downloadFormController.validateDownloadForm(this.form);
+      return downloadFormController.validateDownloadForm(this.form);
     },
 
     /*
@@ -440,76 +425,75 @@ export default {
      * @return {Array of Objects with name, value, and multiple properties}
      */
     getQueryParamArray(currentForm) {
-        let stores = [
-            {name: "countrycode", value: store.state.countrySelectedState}, 
-            {name: "statecode", value: store.state.stateSelectedState},
-            {name: "countycode", value: store.state.countySelectedState},
-            {name: "siteType", value: store.state.sitetypeSelectedState},
-            {name: "charGroup", value: store.state.chargroupSelectedState},
-            {name: "sampleMedia", value: store.state.sampleMediaSelectedState},
-            {name: "organization", value: store.state.orgIDSelectedState},
-            {name: "project", value: store.state.projIDSelectedState},
-            {name: "siteid", value: store.state.siteIDSelectedState},
-            {name: "characteristicName", value: store.state.charSelectedState},
-            {name: "assemblage", value: store.state.assemblageSelectedState},
-            {name: "subjectTaxonomicName", value: store.state.taxSelectedState}
-        ];
+      let stores = [
+        {name: "countrycode", value: store.state.countrySelectedState},
+        {name: "statecode", value: store.state.stateSelectedState},
+        {name: "countycode", value: store.state.countySelectedState},
+        {name: "siteType", value: store.state.sitetypeSelectedState},
+        {name: "charGroup", value: store.state.chargroupSelectedState},
+        {name: "sampleMedia", value: store.state.sampleMediaSelectedState},
+        {name: "organization", value: store.state.orgIDSelectedState},
+        {name: "project", value: store.state.projIDSelectedState},
+        {name: "siteid", value: store.state.siteIDSelectedState},
+        {name: "characteristicName", value: store.state.charSelectedState},
+        {name: "assemblage", value: store.state.assemblageSelectedState},
+        {name: "subjectTaxonomicName", value: store.state.taxSelectedState}
+      ];
 
-        // Need to eliminate form parameters within the mapping-div
-        const formInputs = currentForm.querySelectorAll('input:not(#mapping-div input, #nldi-map input, input[name="dataProfile"]), textarea:not(#mapping-div textarea, #nldi-map textarea), select:not(#mapping-div select, #nldi-map select), button:not(#mapping-div button, #nldi-map button'); 
-        let result = [];
-        let providersArray = [];
-        var length = formInputs.length;
-        formInputs.forEach(function(el, index) {
-            let multiselectArray = [];
-            if (el.type != 'radio' || el.checked || (el.className === 'datasources usa-checkbox__input') ) {
-                if (el.name != 'dataProfile'){
-                    const value = el.value;
-                    const valueIsNotEmpty = typeof value === 'string' ? value : value.length > 0;
-                    const name = el.getAttribute('name');
-                    if (valueIsNotEmpty && name && el.className != 'multiselect__input' && el.className != 'hidden-input') {
-                        if ((valueIsNotEmpty &&  el.className === 'datasources usa-checkbox__input') && (el.checked === true)) {
-                            providersArray.push(value)
-                        } else if (el.className !== 'datasources usa-checkbox__input') {
-                            result.push({
-                                name: name,
-                                value: value,
-                                multiple: el.dataset.multiple ? true : false
-                            });
-                        }
-                    }
-                    if (index === (length - 1)) {
-                        result.push({
-                            name: 'providers',
-                            value: providersArray,
-                            multiple: el.dataset.multiple ? true : false
-                        })
-                    }
-                    else if(el.className === 'hidden-input'){
-                        stores.forEach(function(state){
-                            if (el.name === state.name){
-                                state.value.forEach(function(stateValue){
-                                    multiselectArray.push(stateValue.id);
-                                });
-                                
-                                if(multiselectArray.length !== 0){
-                                    result.push({
-                                        name: state.name,
-                                        value: multiselectArray,
-                                        multiple: el.dataset.multiple ? true : false
-                                    })
-                                }
-                            }
-                        });
-                    }
-                }
+      // Need to eliminate form parameters within the mapping-div
+      const formInputs = currentForm.querySelectorAll('input:not(#mapping-div input, #nldi-map input, input[name="dataProfile"]), textarea:not(#mapping-div textarea, #nldi-map textarea), select:not(#mapping-div select, #nldi-map select), button:not(#mapping-div button, #nldi-map button');
+      let result = [];
+      let providersArray = [];
+      var length = formInputs.length;
+      formInputs.forEach(function (el, index) {
+        let multiselectArray = [];
+        if (el.type != 'radio' || el.checked || (el.className === 'datasources usa-checkbox__input')) {
+          if (el.name != 'dataProfile') {
+            const value = el.value;
+            const valueIsNotEmpty = typeof value === 'string' ? value : value.length > 0;
+            const name = el.getAttribute('name');
+            if (valueIsNotEmpty && name && el.className != 'multiselect__input' && el.className != 'hidden-input') {
+              if ((valueIsNotEmpty && el.className === 'datasources usa-checkbox__input') && (el.checked === true)) {
+                providersArray.push(value)
+              } else if (el.className !== 'datasources usa-checkbox__input') {
+                result.push({
+                  name: name,
+                  value: value,
+                  multiple: el.dataset.multiple ? true : false
+                });
+              }
             }
-        });
-        return result;
+            if (index === (length - 1)) {
+              result.push({
+                name: 'providers',
+                value: providersArray,
+                multiple: el.dataset.multiple ? true : false
+              })
+            } else if (el.className === 'hidden-input') {
+              stores.forEach(function (state) {
+                if (el.name === state.name) {
+                  state.value.forEach(function (stateValue) {
+                    multiselectArray.push(stateValue.id);
+                  });
+
+                  if (multiselectArray.length !== 0) {
+                    result.push({
+                      name: state.name,
+                      value: multiselectArray,
+                      multiple: el.dataset.multiple ? true : false
+                    })
+                  }
+                }
+              });
+            }
+          }
+        }
+      });
+      return result;
     },
 
     getResultType() {
-        return this.dataDetailsView.getResultType();
+      return this.dataDetailsView.getResultType();
     }
   }
 }

--- a/assets/js/views/PlaceInputView.vue
+++ b/assets/js/views/PlaceInputView.vue
@@ -9,7 +9,7 @@ import map from 'lodash/map';
 
 import Vue from 'vue';
 import InputValidationView from './InputValidationView.vue';
-import store from '../store/store.js'
+import store from '../store/store.js';
 import PortalViews from './PortalViews.vue';
 import { getPostalCode } from '../stateFIPS';
 import { getAnchorQueryValues} from '../utils';
@@ -18,17 +18,6 @@ const USA = 'US';
 
 let portalViewClass = Vue.extend(PortalViews);
 let portalViews = new portalViewClass();
-
-/*
- * Initializes and manages the Place inputs
- * @param {Object} options
- *      @prop {NodeList} container - div containing the place inputs.
- *      @prop {CachedCodes} countyModel
- *      @prop {CodesWithKeys} stateModel
- *      @prop {CodesWithKeys} countryModel
- * @returns {Object}
- *      @func initialize
- */
 
 export default {
   name: 'PlaceInputView',
@@ -52,8 +41,8 @@ export default {
         };
 
         portalViews.codeSelect(
-            "getCountryState", 
-            "getCountryOptionsState",
+            'getCountryState',
+            'getCountryOptionsState',
             select,
             spec,
             initValues,
@@ -62,21 +51,12 @@ export default {
 
     },
     initializeCountrySelectBasic(select, model, initValues=[]) {
-        var isMatch = function (searchTerm, lookup) {
-            var termMatcher;
-
+        const isMatch = function (searchTerm, lookup) {
             if (searchTerm) {
-                termMatcher = new RegExp(searchTerm, 'i');
+                const termMatcher = new RegExp(searchTerm, 'i');
                 return termMatcher.test(lookup.id) || termMatcher.test(lookup.desc);
             } else {
                 return true;
-            }
-        };
-        var templateSelection = function(selectData) {
-            if (has(selectData, 'id')) {
-                return selectData.id;
-            } else {
-                return null;
             }
         };
 
@@ -95,12 +75,10 @@ export default {
         );
     },
     initializeStateSelect(select, model, getCountryKeys, initValues=[]) {
-        var isMatch = function (searchTerm, lookup) {
-            var termMatcher;
-            var codes;
+        const isMatch = function (searchTerm, lookup) {
             if (searchTerm) {
-                termMatcher = new RegExp(searchTerm, 'i');
-                codes = lookup.id.split(':');
+                const termMatcher = new RegExp(searchTerm, 'i');
+                const codes = lookup.id.split(':');
                 return termMatcher.test(lookup.id) ||
                     termMatcher.test(lookup.desc) ||
                     termMatcher.test(getPostalCode(codes[1]));
@@ -115,8 +93,8 @@ export default {
         };
 
         portalViews.cascadedCodeSelect(
-            "getStateState",
-            "getStateOptionsState",
+            'getStateState',
+            'getStateOptionsState',
             select,
             spec,
             initValues,
@@ -125,11 +103,9 @@ export default {
     },
     initializeStateSelectBasic(select, model, getCountryKeys, initValues=[]) {
         var isMatch = function (searchTerm, lookup) {
-            var termMatcher;
-            var codes;
             if (searchTerm) {
-                termMatcher = new RegExp(searchTerm, 'i');
-                codes = lookup.id.split(':');
+                const termMatcher = new RegExp(searchTerm, 'i');
+                const codes = lookup.id.split(':');
                 return termMatcher.test(lookup.id) ||
                     termMatcher.test(lookup.desc) ||
                     termMatcher.test(getPostalCode(codes[1]));
@@ -145,8 +121,8 @@ export default {
 
 
         portalViews.cascadedCodeSelect(
-            "getStateState",
-            "getStateOptionsState",
+            'getStateState',
+            'getStateOptionsState',
             select,
             spec,
             initValues,
@@ -155,11 +131,9 @@ export default {
     },
     initializeCountySelect(select, model, getStateKeys, initValues) {
         var isMatch = function(searchTerm, lookup) {
-            var termMatcher;
-            var county;
             if (searchTerm) {
-                termMatcher = new RegExp(searchTerm, 'i');
-                county = last(lookup.desc.split(','));
+                const termMatcher = new RegExp(searchTerm, 'i');
+                const county = last(lookup.desc.split(','));
                 return termMatcher.test(county);
             } else {
                 return true;
@@ -172,8 +146,8 @@ export default {
         };
 
         portalViews.cascadedCodeSelect(
-            "getCountyState",
-            "getCountyOptionsState",
+            'getCountyState',
+            'getCountyOptionsState',
             select,
             countySpec,
             initValues,
@@ -181,12 +155,10 @@ export default {
         );
     },
     initializeCountySelectBasic(select, model, getStateKeys, initValues) {
-        var isMatch = function(searchTerm, lookup) {
-            var termMatcher;
-            var county;
+        const isMatch = function(searchTerm, lookup) {
             if (searchTerm) {
-                termMatcher = new RegExp(searchTerm, 'i');
-                county = last(lookup.desc.split(','));
+                const termMatcher = new RegExp(searchTerm, 'i');
+                const county = last(lookup.desc.split(','));
                 return termMatcher.test(county);
             } else {
                 return true;
@@ -199,8 +171,8 @@ export default {
         };
 
         portalViews.cascadedCodeSelect(
-            "getCountyState",
-            "getCountyOptionsState",
+            'getCountyState',
+            'getCountyOptionsState',
             select,
             countySpec,
             initValues,
@@ -263,7 +235,7 @@ export default {
                 fetchStates = this.stateModel.fetch(union([USA], initCountries));
             }
             fetchStates.then((result) => {
-                store.commit("getStateOptionsState", map(result, (data) => {
+                store.commit('getStateOptionsState', map(result, (data) => {
                     return {
                         id: data.id,
                         text: data.desc + ' (' + self.providers.formatAvailableProviders(data.providers) + ')'
@@ -369,9 +341,11 @@ export default {
         return fetchComplete;
     },
     resetContainer() {
-        let inputs = this.container.querySelector('input[name], select[name], textarea[name], button[name]');
-        inputs.value;
-        inputs.dispatchEvent(new Event('change'));
+        let inputs = this.container.querySelectorAll('input[name], select[name], textarea[name], button[name]');
+        inputs.forEach(function(input) {
+          input.value = '';
+          input.dispatchEvent(new Event('change'));
+        });
     }
   }
 };

--- a/assets/js/views/PointLocationInputView.vue
+++ b/assets/js/views/PointLocationInputView.vue
@@ -93,12 +93,11 @@ export default {
     },
     resetContainer() {
         let inputs = this.container.querySelectorAll('input[name], select[name], textarea[name], button[name]');
-        // inputs.value = '';
         inputs.forEach(function(input) {
             input.value = '';
             input.dispatchEvent(new Event('change'));
         });
     }
   }
-}
+};
 </script>

--- a/server/instance/config.py.sample
+++ b/server/instance/config.py.sample
@@ -5,14 +5,14 @@ VERIFY_CERT = True or False
 SECRET_KEY = 'local_secret_key'
 
 # points to the geoserver endpoint you want to use.
-#WQP_MAP_GEOSERVER_ENDPOINT = 'http://url-to-geoserver'
+WQP_MAP_GEOSERVER_ENDPOINT = 'https://www.waterqualitydata.us/geoserver'
 SITES_MAP_GEOSERVER_ENDPOINT = 'https://www.waterqualitydata.us/ogcservices'
 
 #points to the sld endpoint you want to use.
 SLD_ENDPOINT = 'http://www.waterqualitydata.us/Summary'
 
 # points to the endpoint which returns flow lines and sites for a comid
-NLDI_SERVICES_ENDPOINT = 'https://cida.usgs.gov/nldi/'
+NLDI_SERVICES_ENDPOINT = 'https://labs.waterdata.usgs.gov/api/nldi/linked-data/'
 
 #points to the codes endpoint
 CODES_ENDPOINT = 'https://www.waterqualitydata.us/Codes'
@@ -52,4 +52,4 @@ UI_THEME = 'wqp' or 'usgs'
 
 #ASSET_MANIFEST_PATH = '/Users/dnaab/src/WQP_UI/assets/dist/rev-manifest.json'
 
-STATIC_ROOT = 'http://localhost:9000'
+# Uncomment if using separate static serverSTATIC_ROOT = 'http://localhost:9000'

--- a/server/instance/config.py.sample
+++ b/server/instance/config.py.sample
@@ -1,5 +1,5 @@
 DEBUG = True
-VERIFY_CERT = True or False
+VERIFY_CERT = False
 
 # Do not use the same key as any of the deployment servers
 SECRET_KEY = 'local_secret_key'

--- a/server/wqp/portal_ui_blueprint/templates/index.html
+++ b/server/wqp/portal_ui_blueprint/templates/index.html
@@ -151,7 +151,7 @@
                 </div>
               </div>
               <div class="menu-buttons">
-                <button class="usa-button usa-button--outline reset-params" type="button">Clear search</button>
+                <button class="usa-button usa-button--outline clear-form" type="button">Clear search</button>
                 <button class="usa-button" v-on:click="onNext()" type="button">Next</button>
               </div>
             </div>
@@ -224,7 +224,7 @@
                 </div>
               </div>
               <div class="menu-buttons">
-                <button class="usa-button usa-button--outline reset-filters" type="button">Clear search</button>
+                <button class="usa-button usa-button--outline clear-form" type="button">Clear search</button>
                 <button class="usa-button" v-on:click="onPrev()" type="button">Previous</button>
                 <button class="usa-button" v-on:click="onNext()" type="button">Next</button>
               </div>
@@ -301,7 +301,7 @@
                 <div class="tooltip" :title="sortDataTooltip" class="control-label" for="control-label"><span class="tooltipIcon"><img src="{{ 'img/info.svg' | asset_url }}" alt="info"/></span></div>
                 </div>
               <div class="menu-buttons">
-                <button class="usa-button usa-button--outline" v-on:click="onStartOver()" id="startOver" type="button">Start over</button>
+                <button class="clear-form usa-button usa-button--outline" v-on:click="onStartOver()" id="startOver" type="button">Start over</button>
                 <button class="usa-button" v-on:click="onPrev()"  type="button">Previous</button>
                 <a class="usa-button main-button" id="basic-main-button" href="#download-status-modal-basic" type="submit" aria-controls="download-status-modal-basic" data-open-modal>Download</a>
                 <div class="usa-modal" id="download-status-modal-basic" aria-labelledby="download-status-modal-basic-heading"
@@ -838,7 +838,7 @@
                             </div>
                           </div>
                         </div>
-                        <button class="usa-button usa-button--outline" v-on:click="onAdvancedStartOver()" id="advancedStartOver" type="button">Clear search</button>
+                        <button class="clear-form usa-button usa-button--outline" v-on:click="onAdvancedStartOver()" id="advancedStartOver" type="button">Clear search</button>
                         <a href="#download-status-modal" id="main-button" class="usa-button main-button" type="submit"
                           aria-controls="download-status-modal" data-open-modal>
                           Download


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Fixed how Clear Search/Start Over buttons work

Description
-----------
Modified the code so now when Clear Search/Start Over are clicked, *all* form inputs are reset to their default values. Also fixed the reset for the placeInputView component so that it clears the NLDI section. Prior to this change the Clear Search button would only clear what was on that page/step and that we feel is confusing, especially when clearing the basic form was not clearing the advanced form unless those fields appeared i both places.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
